### PR TITLE
Make builds headless

### DIFF
--- a/centos-5/template.json
+++ b/centos-5/template.json
@@ -5,6 +5,7 @@
 		{
 			"name": "vagrant-centos-5.x86_64",
 			"type": "virtualbox-iso",
+			"headless": true,
 			"iso_checksum": "b6eb0565b636513b90663ff01c6ec4da5058baff0d7d4007d187be997dd985f8",
 			"iso_checksum_type": "sha256",
 			"iso_url": "{{user `mirror`}}/centos/5.11/isos/x86_64/CentOS-5.11-x86_64-bin-DVD-1of2.iso",

--- a/centos-6/template.json
+++ b/centos-6/template.json
@@ -5,6 +5,7 @@
 		{
 			"name": "vagrant-centos-6.x86_64",
 			"type": "virtualbox-iso",
+			"headless": true,
 			"iso_checksum": "ec49c297d484b9da0787e5944edc38f7c70f21c0f6a60178d8e9a8926d1949f4",
 			"iso_checksum_type": "sha256",
 			"iso_url": "{{user `mirror`}}/centos/6.8/isos/x86_64/CentOS-6.8-x86_64-minimal.iso",

--- a/centos-7/template.json
+++ b/centos-7/template.json
@@ -5,6 +5,7 @@
 		{
 			"name": "vagrant-centos-7.x86_64",
 			"type": "virtualbox-iso",
+			"headless": true,
 			"iso_checksum": "27bd866242ee058b7a5754e83d8ee8403e216b93d130d800852a96f41c34d86a",
 			"iso_checksum_type": "sha256",
 			"iso_url": "{{user `mirror`}}/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1611.iso",

--- a/ubuntu-xenial/template.json
+++ b/ubuntu-xenial/template.json
@@ -5,6 +5,7 @@
 		{
 			"name": "vagrant-ubuntu-xenial.amd64",
 			"type": "virtualbox-iso",
+			"headless": true,
 			"iso_checksum": "29a8b9009509b39d542ecb229787cdf48f05e739a932289de9e9858d7c487c80",
 			"iso_checksum_type": "sha256",
 			"iso_url": "{{user `mirror`}}/ubuntu-releases/xenial/ubuntu-16.04.1-server-amd64.iso",


### PR DESCRIPTION
A GUI can be a great asset for troubleshooting a failing build but
isn't necessary for typical builds. From experience, users can't
seem to resist messing with the VM when a GUI is present and that
can cause the build to fail.

The GUI can be re-enabled by setting the headless option to false.